### PR TITLE
Use external port instead of internal port

### DIFF
--- a/docker-install-pat-macosx.py
+++ b/docker-install-pat-macosx.py
@@ -42,13 +42,21 @@ c = Client(base_url= url, tls=tls_config)
 
 ports = c.inspect_container(args.container)['NetworkSettings']['Ports']
 
-for portinfo in ports:
+for portinfo, portdetails in ports.iteritems():
     if ports[portinfo] is not None:
-        [port, proto] = portinfo.split("/")
-        rulename = proto + "-port" + port
+        [internal_port, proto] = portinfo.split("/")
+
+        # Catch external port instead of internal
+        external_port =''
+        if ports[portinfo][0]['HostPort'] is not None:
+            external_port = ports[portinfo][0]['HostPort']
+        else:
+            external_port = internal_port
+
+        rulename = proto + "-port" + external_port
 
         if args.action == 'add':
-            natrule = rulename + "," + proto + ",," + port + ",," + port
+            natrule = rulename + "," + proto + ",," + external_port + ",," + external_port
             natcmd = 'VBoxManage controlvm "default" natpf1 ' + '""' + natrule + '""'
             print "NATRULE: " + natrule
             subprocess.call(natcmd, shell=True)


### PR DESCRIPTION
I updated the code to use the external port to construct the NAT rule instead of the internal one

For this container for example, the internal port is 51000 and the external port 514
Currently the script create a NAT rule for 51000

```
CONTAINER ID        IMAGE                     COMMAND                  CREATED             STATUS              PORTS                               NAMES
38e9eb94cf83        juniper/junos-dogstatsd   "/sbin/my_init"          27 minutes ago      Up 27 minutes       51020/tcp, 0.0.0.0:514->51000/udp   lonely_kare
```
